### PR TITLE
frontend: MetaMask-only fallback; add favicon and seed lesson

### DIFF
--- a/packages/frontend/index.html
+++ b/packages/frontend/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Lythera Ecosystem</title>
+    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Ctext y='14' font-size='14'%3E🦅%3C/text%3E%3C/svg%3E">
   </head>
   <body>
     <div id="root"></div>

--- a/packages/frontend/public/content/cohorts.json
+++ b/packages/frontend/public/content/cohorts.json
@@ -1,0 +1,7 @@
+[
+  {
+    "name": "Alpha-01",
+    "cap": 100,
+    "windowDays": 30
+  }
+]

--- a/packages/frontend/public/content/department1/lesson1.md
+++ b/packages/frontend/public/content/department1/lesson1.md
@@ -1,0 +1,3 @@
+# Department 1 Lesson 1
+
+Content placeholder.

--- a/packages/frontend/public/content/department1/lesson2.md
+++ b/packages/frontend/public/content/department1/lesson2.md
@@ -1,0 +1,3 @@
+# Department 1 Lesson 2
+
+Content placeholder.

--- a/packages/frontend/public/content/department1/lesson3.md
+++ b/packages/frontend/public/content/department1/lesson3.md
@@ -1,0 +1,3 @@
+# Department 1 Lesson 3
+
+Content placeholder.

--- a/packages/frontend/public/content/department1/questions.json
+++ b/packages/frontend/public/content/department1/questions.json
@@ -1,0 +1,17 @@
+[
+  {"q": "Question 1?", "a": "Answer"},
+  {"q": "Question 2?", "a": "Answer"},
+  {"q": "Question 3?", "a": "Answer"},
+  {"q": "Question 4?", "a": "Answer"},
+  {"q": "Question 5?", "a": "Answer"},
+  {"q": "Question 6?", "a": "Answer"},
+  {"q": "Question 7?", "a": "Answer"},
+  {"q": "Question 8?", "a": "Answer"},
+  {"q": "Question 9?", "a": "Answer"},
+  {"q": "Question 10?", "a": "Answer"},
+  {"q": "Question 11?", "a": "Answer"},
+  {"q": "Question 12?", "a": "Answer"},
+  {"q": "Question 13?", "a": "Answer"},
+  {"q": "Question 14?", "a": "Answer"},
+  {"q": "Question 15?", "a": "Answer"}
+]

--- a/packages/frontend/public/content/department2/lesson1.md
+++ b/packages/frontend/public/content/department2/lesson1.md
@@ -1,0 +1,3 @@
+# Department 2 Lesson 1
+
+Content placeholder.

--- a/packages/frontend/public/content/department2/lesson2.md
+++ b/packages/frontend/public/content/department2/lesson2.md
@@ -1,0 +1,3 @@
+# Department 2 Lesson 2
+
+Content placeholder.

--- a/packages/frontend/public/content/department2/lesson3.md
+++ b/packages/frontend/public/content/department2/lesson3.md
@@ -1,0 +1,3 @@
+# Department 2 Lesson 3
+
+Content placeholder.

--- a/packages/frontend/public/content/department2/questions.json
+++ b/packages/frontend/public/content/department2/questions.json
@@ -1,0 +1,17 @@
+[
+  {"q": "Question 1?", "a": "Answer"},
+  {"q": "Question 2?", "a": "Answer"},
+  {"q": "Question 3?", "a": "Answer"},
+  {"q": "Question 4?", "a": "Answer"},
+  {"q": "Question 5?", "a": "Answer"},
+  {"q": "Question 6?", "a": "Answer"},
+  {"q": "Question 7?", "a": "Answer"},
+  {"q": "Question 8?", "a": "Answer"},
+  {"q": "Question 9?", "a": "Answer"},
+  {"q": "Question 10?", "a": "Answer"},
+  {"q": "Question 11?", "a": "Answer"},
+  {"q": "Question 12?", "a": "Answer"},
+  {"q": "Question 13?", "a": "Answer"},
+  {"q": "Question 14?", "a": "Answer"},
+  {"q": "Question 15?", "a": "Answer"}
+]

--- a/packages/frontend/public/content/department3/lesson1.md
+++ b/packages/frontend/public/content/department3/lesson1.md
@@ -1,0 +1,3 @@
+# Department 3 Lesson 1
+
+Content placeholder.

--- a/packages/frontend/public/content/department3/lesson2.md
+++ b/packages/frontend/public/content/department3/lesson2.md
@@ -1,0 +1,3 @@
+# Department 3 Lesson 2
+
+Content placeholder.

--- a/packages/frontend/public/content/department3/lesson3.md
+++ b/packages/frontend/public/content/department3/lesson3.md
@@ -1,0 +1,3 @@
+# Department 3 Lesson 3
+
+Content placeholder.

--- a/packages/frontend/public/content/department3/questions.json
+++ b/packages/frontend/public/content/department3/questions.json
@@ -1,0 +1,17 @@
+[
+  {"q": "Question 1?", "a": "Answer"},
+  {"q": "Question 2?", "a": "Answer"},
+  {"q": "Question 3?", "a": "Answer"},
+  {"q": "Question 4?", "a": "Answer"},
+  {"q": "Question 5?", "a": "Answer"},
+  {"q": "Question 6?", "a": "Answer"},
+  {"q": "Question 7?", "a": "Answer"},
+  {"q": "Question 8?", "a": "Answer"},
+  {"q": "Question 9?", "a": "Answer"},
+  {"q": "Question 10?", "a": "Answer"},
+  {"q": "Question 11?", "a": "Answer"},
+  {"q": "Question 12?", "a": "Answer"},
+  {"q": "Question 13?", "a": "Answer"},
+  {"q": "Question 14?", "a": "Answer"},
+  {"q": "Question 15?", "a": "Answer"}
+]

--- a/packages/frontend/public/content/department4/lesson1.md
+++ b/packages/frontend/public/content/department4/lesson1.md
@@ -1,0 +1,3 @@
+# Department 4 Lesson 1
+
+Content placeholder.

--- a/packages/frontend/public/content/department4/lesson2.md
+++ b/packages/frontend/public/content/department4/lesson2.md
@@ -1,0 +1,3 @@
+# Department 4 Lesson 2
+
+Content placeholder.

--- a/packages/frontend/public/content/department4/lesson3.md
+++ b/packages/frontend/public/content/department4/lesson3.md
@@ -1,0 +1,3 @@
+# Department 4 Lesson 3
+
+Content placeholder.

--- a/packages/frontend/public/content/department4/questions.json
+++ b/packages/frontend/public/content/department4/questions.json
@@ -1,0 +1,17 @@
+[
+  {"q": "Question 1?", "a": "Answer"},
+  {"q": "Question 2?", "a": "Answer"},
+  {"q": "Question 3?", "a": "Answer"},
+  {"q": "Question 4?", "a": "Answer"},
+  {"q": "Question 5?", "a": "Answer"},
+  {"q": "Question 6?", "a": "Answer"},
+  {"q": "Question 7?", "a": "Answer"},
+  {"q": "Question 8?", "a": "Answer"},
+  {"q": "Question 9?", "a": "Answer"},
+  {"q": "Question 10?", "a": "Answer"},
+  {"q": "Question 11?", "a": "Answer"},
+  {"q": "Question 12?", "a": "Answer"},
+  {"q": "Question 13?", "a": "Answer"},
+  {"q": "Question 14?", "a": "Answer"},
+  {"q": "Question 15?", "a": "Answer"}
+]

--- a/packages/frontend/public/content/rewards.json
+++ b/packages/frontend/public/content/rewards.json
@@ -1,0 +1,6 @@
+{
+  "Beginner": 5,
+  "Intermediate": 10,
+  "Advanced": 15,
+  "GCC Spotlight": 20
+}

--- a/packages/frontend/src/App.jsx
+++ b/packages/frontend/src/App.jsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, useParams } from 'react-router-dom';
 import WalletButton from './components/WalletButton';
 import NetworkGuard from './components/NetworkGuard';
 import MarkdownRenderer from './components/MarkdownRenderer';
@@ -6,10 +6,20 @@ import QuizEngine from './components/QuizEngine';
 import AdminPublisher from './components/AdminPublisher';
 import ProgressBar from './components/ProgressBar';
 import CohortBadge from './components/CohortBadge';
-import Dashboard from './pages/Dashboard';
+import RewardSummary from './components/RewardSummary';
 
-function Placeholder({ text }) {
-  return <div>{text}</div>;
+function Placeholder({ text }) { return <div>{text}</div>; }
+
+function DeptPage() {
+  const { deptId } = useParams();
+  const map = {
+    department1: '/content/department1/lesson1.md',
+    department2: '/content/department2/lesson1.md',
+    department3: '/content/department3/lesson1.md',
+    department4: '/content/department4/lesson1.md'
+  };
+  const uri = map[deptId];
+  return uri ? <MarkdownRenderer uri={uri} /> : <div>Unknown department</div>;
 }
 
 export default function App() {
@@ -21,9 +31,9 @@ export default function App() {
           <Route path="/" element={<Placeholder text="home" />} />
           <Route path="/profile" element={<Placeholder text="profile" />} />
           <Route path="/learn" element={<Placeholder text="learn" />} />
-          <Route path="/learn/:deptId" element={<MarkdownRenderer />} />
+          <Route path="/learn/:deptId" element={<DeptPage />} />
           <Route path="/quiz/:deptId" element={<QuizEngine />} />
-          <Route path="/dashboard" element={<Dashboard />} />
+          <Route path="/dashboard" element={<RewardSummary />} />
           <Route path="/admin" element={<AdminPublisher />} />
           <Route path="/community" element={<Placeholder text="community" />} />
           <Route path="/blog" element={<Placeholder text="blog" />} />

--- a/packages/frontend/src/components/WalletButton.jsx
+++ b/packages/frontend/src/components/WalletButton.jsx
@@ -1,25 +1,59 @@
 import { useState } from 'react';
+import { ethers } from 'ethers';
 import { createWeb3Modal, defaultConfig } from '@web3modal/ethers';
 
 const projectId = import.meta.env.VITE_WC_PROJECT_ID;
 const chains = [{ chainId: 56, name: 'BSC', rpcUrl: import.meta.env.VITE_RPC_URL }];
-const modal = createWeb3Modal({ ethersConfig: defaultConfig({ appName: 'Lythera', chains, projectId }) });
+
+let modal = null;
+if (projectId) {
+  modal = createWeb3Modal({
+    ethersConfig: defaultConfig({ appName: 'Lythera', chains, projectId })
+  });
+}
 
 export default function WalletButton() {
   const [address, setAddress] = useState();
 
-  async function connect() {
+  async function connectWithModal() {
     const provider = await modal.connectWallet();
     await provider.switchNetwork(56);
     const accounts = await provider.getAccounts();
     setAddress(accounts[0]);
   }
 
+  async function connectWithMetaMask() {
+    if (!window.ethereum) {
+      alert('MetaMask not detected. Please install MetaMask or set VITE_WC_PROJECT_ID for WalletConnect.');
+      return;
+    }
+    const provider = new ethers.BrowserProvider(window.ethereum);
+    await provider.send('wallet_addEthereumChain', [{
+      chainId: '0x38',
+      chainName: 'BNB Smart Chain',
+      nativeCurrency: { name: 'BNB', symbol: 'BNB', decimals: 18 },
+      rpcUrls: [import.meta.env.VITE_RPC_URL],
+      blockExplorerUrls: [import.meta.env.VITE_EXPLORER_URL]
+    }]);
+    const accounts = await provider.send('eth_requestAccounts', []);
+    setAddress(accounts[0]);
+  }
+
+  async function connect() {
+    try {
+      if (modal) return await connectWithModal();
+      return await connectWithMetaMask();
+    } catch (e) {
+      console.error(e);
+      alert('Wallet connect failed: ' + (e?.message || e));
+    }
+  }
+
   function disconnect() {
-    modal.disconnect();
+    if (modal) modal.disconnect();
     setAddress(undefined);
   }
 
-  const text = address ? address.slice(0, 6) + '…' : 'Connect Wallet';
+  const text = address ? address.slice(0, 6) + '…' + address.slice(-4) : 'Connect Wallet';
   return <button onClick={address ? disconnect : connect}>{text}</button>;
 }


### PR DESCRIPTION
## Summary
- allow WalletButton to fall back to MetaMask when no WalletConnect project ID is set
- add inline SVG favicon to silence 404s
- route department pages to bundled markdown and serve seed lesson content

## Testing
- `yarn workspace frontend dev` *(fails: This package doesn't seem to be present in your lockfile; run "yarn install" to update the lockfile)*
- `yarn install` *(fails: RequestError: Bad response: 403)*

------
https://chatgpt.com/codex/tasks/task_e_68accf7a4bcc832ba80df4db52a2939d