### PR TITLE
frontend: add lesson navigation and quiz

### DIFF
--- a/packages/frontend/src/App.jsx
+++ b/packages/frontend/src/App.jsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Routes, Route, useParams } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, Link, useParams, useNavigate } from 'react-router-dom';
 import WalletButton from './components/WalletButton';
 import NetworkGuard from './components/NetworkGuard';
 import MarkdownRenderer from './components/MarkdownRenderer';
@@ -8,30 +8,66 @@ import ProgressBar from './components/ProgressBar';
 import CohortBadge from './components/CohortBadge';
 import RewardSummary from './components/RewardSummary';
 
-function Placeholder({ text }) { return <div>{text}</div>; }
+function Placeholder({ text }) { return <div style={{ padding: 16 }}>{text}</div>; }
 
-function DeptPage() {
-  const { deptId } = useParams();
-  const map = {
-    department1: '/content/department1/lesson1.md',
-    department2: '/content/department2/lesson1.md',
-    department3: '/content/department3/lesson1.md',
-    department4: '/content/department4/lesson1.md'
-  };
-  const uri = map[deptId];
-  return uri ? <MarkdownRenderer uri={uri} /> : <div>Unknown department</div>;
+const DEPTS = ['department1','department2','department3','department4'];
+const LESSONS = ['1','2','3'];
+
+function DeptNav({ deptId, active }) {
+  return (
+    <div style={{ display: 'flex', gap: 8, padding: '8px 16px' }}>
+      {LESSONS.map(id => {
+        const to = `/learn/${deptId}/${id}`;
+        const isActive = active === id;
+        return (
+          <Link key={id} to={to} style={{
+            padding: '4px 10px',
+            borderRadius: 6,
+            textDecoration: 'none',
+            background: isActive ? '#ffd166' : '#333',
+            color: isActive ? '#111' : '#fff'
+          }}>
+            Lesson {id}
+          </Link>
+        );
+      })}
+      <Link to={`/quiz/${deptId}`} style={{ marginLeft: 'auto', color: '#ffd166' }}>Take Quiz →</Link>
+    </div>
+  );
+}
+
+function DeptLessonPage() {
+  const { deptId, lessonId } = useParams();
+  const navigate = useNavigate();
+  if (!DEPTS.includes(deptId || '')) return <Placeholder text="Unknown department" />;
+  if (!LESSONS.includes(lessonId || '')) {
+    // default to lesson 1 if missing/bad
+    navigate(`/learn/${deptId}/1`, { replace: true });
+    return null;
+  }
+  const uri = `/content/${deptId}/lesson${lessonId}.md`;
+  return (
+    <div>
+      <DeptNav deptId={deptId} active={lessonId} />
+      <div style={{ padding: 16 }}>
+        <MarkdownRenderer uri={uri} title={`${deptId} • Lesson ${lessonId}`} />
+      </div>
+    </div>
+  );
 }
 
 export default function App() {
   return (
     <BrowserRouter>
       <NetworkGuard>
-        <WalletButton />
+        <div style={{ padding: 12 }}>
+          <WalletButton />
+        </div>
         <Routes>
           <Route path="/" element={<Placeholder text="home" />} />
           <Route path="/profile" element={<Placeholder text="profile" />} />
-          <Route path="/learn" element={<Placeholder text="learn" />} />
-          <Route path="/learn/:deptId" element={<DeptPage />} />
+          <Route path="/learn" element={<Placeholder text="Pick a department: /learn/department1/1" />} />
+          <Route path="/learn/:deptId/:lessonId" element={<DeptLessonPage />} />
           <Route path="/quiz/:deptId" element={<QuizEngine />} />
           <Route path="/dashboard" element={<RewardSummary />} />
           <Route path="/admin" element={<AdminPublisher />} />
@@ -43,3 +79,4 @@ export default function App() {
     </BrowserRouter>
   );
 }
+

--- a/packages/frontend/src/components/MarkdownRenderer.jsx
+++ b/packages/frontend/src/components/MarkdownRenderer.jsx
@@ -1,10 +1,11 @@
 import { useEffect, useState } from 'react';
 import { marked } from 'marked';
 
-export default function MarkdownRenderer({ uri, hash }) {
+export default function MarkdownRenderer({ uri, hash, title }) {
   const [html, setHtml] = useState('');
 
   useEffect(() => {
+    let cancelled = false;
     async function load() {
       if (!uri) return;
       const res = await fetch(uri);
@@ -12,13 +13,20 @@ export default function MarkdownRenderer({ uri, hash }) {
       const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(text));
       const hex = Array.from(new Uint8Array(digest)).map(b => b.toString(16).padStart(2, '0')).join('');
       if (!hash || hash === hex) {
-        setHtml(marked(text));
+        if (!cancelled) setHtml(marked(text));
       } else {
-        setHtml('hash mismatch');
+        if (!cancelled) setHtml('<em>hash mismatch</em>');
       }
     }
     load();
+    return () => { cancelled = true; };
   }, [uri, hash]);
 
-  return <div dangerouslySetInnerHTML={{ __html: html }} />;
+  return (
+    <div>
+      {title ? <h2 style={{ marginTop: 0 }}>{title}</h2> : null}
+      <div dangerouslySetInnerHTML={{ __html: html }} />
+    </div>
+  );
 }
+

--- a/packages/frontend/src/components/QuizEngine.jsx
+++ b/packages/frontend/src/components/QuizEngine.jsx
@@ -1,12 +1,109 @@
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
 
+function shuffle(arr) {
+  const a = arr.slice();
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+}
+
+/**
+ * Expected seed format (simple):
+ * [
+ *   {"q": "Question 1?", "a": "Answer"},
+ *   ...
+ * ]
+ * Later we can support multi-choice { choices: [...], correct: [...] }.
+ */
 export default function QuizEngine() {
-  const [mode, setMode] = useState('A');
+  const { deptId } = useParams();
+  const [status, setStatus] = useState('loading'); // loading | ready | done | error
+  const [items, setItems] = useState([]);
+  const [answers, setAnswers] = useState({});
+  const [score, setScore] = useState(0);
+
+  const uri = deptId ? `/content/${deptId}/questions.json` : null;
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      try {
+        if (!uri) return;
+        const res = await fetch(uri);
+        if (!res.ok) throw new Error(`Cannot load ${uri}`);
+        const json = await res.json();
+        if (!cancelled) {
+          // light randomization
+          setItems(shuffle(json).slice(0, Math.min(10, json.length)));
+          setStatus('ready');
+        }
+      } catch (e) {
+        console.error(e);
+        if (!cancelled) setStatus('error');
+      }
+    }
+    load();
+    return () => { cancelled = true; };
+  }, [uri]);
+
+  const total = items.length;
+  const correctCount = useMemo(() => {
+    return items.reduce((acc, item, idx) => {
+      if (answers[idx] === item.a) return acc + 1;
+      return acc;
+    }, 0);
+  }, [answers, items]);
+
+  function submit() {
+    setScore(correctCount);
+    setStatus('done');
+  }
+
+  if (!deptId) return <div style={{ padding: 16 }}>No department</div>;
+  if (status === 'loading') return <div style={{ padding: 16 }}>Loading questions…</div>;
+  if (status === 'error') return <div style={{ padding: 16, color: '#f66' }}>Failed to load {uri}</div>;
+
+  if (status === 'done') {
+    const pct = total ? Math.round((score / total) * 100) : 0;
+    return (
+      <div style={{ padding: 16 }}>
+        <h2>Quiz Result — {deptId}</h2>
+        <p>Score: {score} / {total} ({pct}%)</p>
+        <Link to={`/learn/${deptId}/1`} style={{ color: '#ffd166' }}>Back to lessons</Link>
+      </div>
+    );
+  }
 
   return (
-    <div>
-      <p>Quiz Engine (Mode {mode})</p>
-      {/* TODO: commit-reveal and attest logic */}
+    <div style={{ padding: 16 }}>
+      <h2>Quiz — {deptId}</h2>
+      <ol>
+        {items.map((it, idx) => (
+          <li key={idx} style={{ margin: '12px 0' }}>
+            <div style={{ marginBottom: 8 }}>{it.q}</div>
+            <input
+              type="text"
+              placeholder="Type your answer"
+              value={answers[idx] || ''}
+              onChange={e => setAnswers(a => ({ ...a, [idx]: e.target.value }))}
+              style={{
+                width: '100%',
+                maxWidth: 420,
+                padding: 8,
+                background: '#222',
+                color: '#fff',
+                border: '1px solid #444',
+                borderRadius: 6
+              }}
+            />
+          </li>
+        ))}
+      </ol>
+      <button onClick={submit} style={{ padding: '8px 14px', borderRadius: 6 }}>Submit</button>
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary
- add in-lesson navigation and quiz link via /learn/:deptId/:lessonId routes
- allow optional title rendering in MarkdownRenderer
- implement QuizEngine reading department questions.json

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`
- `npm run build` (fails: Invalid option schema)


------
https://chatgpt.com/codex/tasks/task_e_68ad4f9516dc832ba0308362f20ae921