### PR TITLE
feat(frontend): replace web3modal with metamask

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -12,7 +12,6 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.14.1",
     "ethers": "^6.6.0",
-    "@web3modal/ethers": "^3.0.0",
     "marked": "^9.0.0"
   },
   "devDependencies": {

--- a/packages/frontend/src/components/WalletButton.jsx
+++ b/packages/frontend/src/components/WalletButton.jsx
@@ -1,114 +1,66 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { ethers } from 'ethers';
-import { createWeb3Modal, defaultConfig } from '@web3modal/ethers';
 
-// --- env & defaults ----------------------------------------------------------
+// BSC (56) constants + safe defaults
+const CHAIN_ID_DEC = 56;
 const CHAIN_ID_HEX = '0x38'; // 56
-const FALLBACK_RPC = 'https://bsc-dataseed.binance.org';
-const FALLBACK_EXPLORER = 'https://bscscan.com';
-
-const WC_PROJECT_ID = import.meta.env.VITE_WC_PROJECT_ID;
-const RPC_URL = import.meta.env.VITE_RPC_URL || FALLBACK_RPC;
-const EXPLORER_URL = import.meta.env.VITE_EXPLORER_URL || FALLBACK_EXPLORER;
-
-// --- optional Web3Modal (only if project id is provided) ---------------------
-const chains = [{ chainId: 56, name: 'BSC', rpcUrl: RPC_URL }];
-const modal =
-  WC_PROJECT_ID
-    ? createWeb3Modal({
-        ethersConfig: defaultConfig({ appName: 'Lythera', chains, projectId: WC_PROJECT_ID })
-      })
-    : null;
+const RPC_URL = import.meta.env.VITE_RPC_URL || 'https://bsc-dataseed.binance.org';
+const EXPLORER_URL = import.meta.env.VITE_EXPLORER_URL || 'https://bscscan.com';
 
 export default function WalletButton() {
   const [address, setAddress] = useState();
   const mounted = useRef(true);
 
-  useEffect(() => {
-    return () => {
-      mounted.current = false; // prevent setState on unmount
-    };
-  }, []);
+  useEffect(() => () => { mounted.current = false; }, []);
 
   const hasEthereum = typeof window !== 'undefined' && window.ethereum;
-
-  const metaMaskProvider = useMemo(() => {
+  const provider = useMemo(() => {
     if (!hasEthereum) return null;
-    try {
-      return new ethers.BrowserProvider(window.ethereum);
-    } catch {
-      return null;
-    }
+    try { return new ethers.BrowserProvider(window.ethereum); } catch { return null; }
   }, [hasEthereum]);
 
-  async function ensureBSCWithMetaMask(provider) {
-    // Try to switch first
+  async function ensureBSC() {
+    if (!provider) throw new Error('MetaMask not detected');
+    // Try to switch first (fast path)
     try {
       await provider.send('wallet_switchEthereumChain', [{ chainId: CHAIN_ID_HEX }]);
       return;
     } catch (err) {
-      // 4902 = chain not added; otherwise rethrow
       const needsAdd =
         err?.code === 4902 ||
         (typeof err?.message === 'string' && /add.*chain|unrecognized chain/i.test(err.message));
       if (!needsAdd) throw err;
     }
-
-    // Add the chain with valid HTTPS URLs
-    await provider.send('wallet_addEthereumChain', [
-      {
-        chainId: CHAIN_ID_HEX,
-        chainName: 'BNB Smart Chain',
-        nativeCurrency: { name: 'BNB', symbol: 'BNB', decimals: 18 },
-        rpcUrls: [RPC_URL],
-        blockExplorerUrls: [EXPLORER_URL]
-      }
-    ]);
-  }
-
-  async function connectWithModal() {
-    const provider = await modal.connectWallet();
-    // Web3Modal provider has helpers
-    await provider.switchNetwork(56);
-    const accounts = await provider.getAccounts();
-    if (mounted.current) setAddress(accounts[0]);
-  }
-
-  async function connectWithMetaMask() {
-    if (!metaMaskProvider) {
-      alert('MetaMask not detected. Please install MetaMask or set VITE_WC_PROJECT_ID to use WalletConnect.');
-      return;
-    }
-    await ensureBSCWithMetaMask(metaMaskProvider);
-    const accounts = await metaMaskProvider.send('eth_requestAccounts', []);
-    if (mounted.current) setAddress(accounts[0]);
+    // Add BSC with valid HTTPS urls
+    await provider.send('wallet_addEthereumChain', [{
+      chainId: CHAIN_ID_HEX,
+      chainName: 'BNB Smart Chain',
+      nativeCurrency: { name: 'BNB', symbol: 'BNB', decimals: 18 },
+      rpcUrls: [RPC_URL],
+      blockExplorerUrls: [EXPLORER_URL]
+    }]);
   }
 
   async function connect() {
     try {
-      if (modal) return await connectWithModal();
-      return await connectWithMetaMask();
+      if (!provider) {
+        alert('MetaMask not detected. Please install MetaMask.');
+        return;
+      }
+      await ensureBSC();
+      const accounts = await provider.send('eth_requestAccounts', []);
+      if (mounted.current) setAddress(accounts[0]);
     } catch (e) {
       console.error('[wallet connect] error:', e);
-      const msg =
-        e?.message ||
-        (typeof e === 'string' ? e : 'Wallet connect failed. Check network and RPC/Explorer env values.');
-      alert(msg);
+      alert(e?.message || 'Wallet connect failed.');
     }
   }
 
   function disconnect() {
-    try {
-      if (modal) modal.disconnect();
-    } finally {
-      if (mounted.current) setAddress(undefined);
-    }
+    if (mounted.current) setAddress(undefined);
   }
 
-  const btnLabel = address ? `${address.slice(0, 6)}…${address.slice(-4)}` : 'Connect Wallet';
-  return (
-    <button onClick={address ? disconnect : connect}>
-      {btnLabel}
-    </button>
-  );
+  const label = address ? `${address.slice(0, 6)}…${address.slice(-4)}` : 'Connect Wallet';
+  return <button onClick={address ? disconnect : connect}>{label}</button>;
 }
+


### PR DESCRIPTION
## Summary
- replace Web3Modal wallet integration with direct MetaMask using ethers v6
- remove `@web3modal/ethers` dependency

## Testing
- `corepack enable`
- `yarn set version stable` *(fails: Bad response 403)*
- `yarn -v`
- `yarn workspaces focus frontend` *(fails: Bad response 403)*
- `yarn install --immutable` *(fails: lockfile would have been created)*
- `yarn workspace frontend dev` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2ad8bf44832bb5e1b22ef0b441ea