### PR TITLE
Unified dev without extra deps (Node launcher)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,15 +3,12 @@
   "private": true,
   "workspaces": ["packages/*"],
   "scripts": {
-    "dev": "concurrently -k -n SERVER,FRONTEND -c yellow,cyan \"yarn workspace server dev\" \"yarn workspace frontend dev -- --host --port 5173\"",
+    "dev": "node tools/dev.mjs",
     "dev:server": "yarn workspace server dev",
     "dev:frontend": "yarn workspace frontend dev -- --host --port 5173",
     "build": "yarn workspaces foreach -pt run build",
     "format": "echo format",
     "lint": "echo lint"
-  },
-  "devDependencies": {
-    "concurrently": "^9.0.1"
   },
   "packageManager": "yarn@4.9.4"
 }

--- a/tools/dev.mjs
+++ b/tools/dev.mjs
@@ -1,0 +1,19 @@
+// Simple cross-platform launcher using Node built-ins.
+// Runs: yarn workspace server dev  AND  yarn workspace frontend dev -- --host --port 5173
+import { spawn } from 'node:child_process';
+
+function run(name, cmd, args) {
+  const p = spawn(cmd, args, { stdio: 'inherit', shell: true });
+  p.on('exit', code => {
+    console.log(`[${name}] exited with code ${code}`);
+    // If either process exits, kill the other (best-effort)
+    try { server?.kill(); } catch {}
+    try { frontend?.kill(); } catch {}
+    process.exit(code ?? 0);
+  });
+  return p;
+}
+
+const server = run('server', 'yarn', ['workspace', 'server', 'dev']);
+const frontend = run('frontend', 'yarn', ['workspace', 'frontend', 'dev', '--', '--host', '--port', '5173']);
+


### PR DESCRIPTION
## Summary
- replace `concurrently` with lightweight Node launcher script
- add unified `yarn dev` script for server and frontend

## Testing
- `yarn -v` *(fails: Error when performing the request to https://repo.yarnpkg.com/...)*
- `node tools/dev.mjs` *(fails: Error when performing the request to https://repo.yarnpkg.com/...)*

------
https://chatgpt.com/codex/tasks/task_e_68b03f155b10832bb9c40878328b009d