### PR TITLE
feat: gate lessons with quiz progress

### DIFF
--- a/packages/frontend/src/App.jsx
+++ b/packages/frontend/src/App.jsx
@@ -4,14 +4,38 @@ import NetworkGuard from './components/NetworkGuard';
 import MarkdownRenderer from './components/MarkdownRenderer';
 import QuizEngine from './components/QuizEngine';
 import AdminPublisher from './components/AdminPublisher';
-import ProgressBar from './components/ProgressBar';
-import CohortBadge from './components/CohortBadge';
 import RewardSummary from './components/RewardSummary';
+import CohortBadge from './components/CohortBadge';
+import { isDeptUnlocked, isDeptCompleted } from './store/progress';
 
 function Placeholder({ text }) { return <div style={{ padding: 16 }}>{text}</div>; }
 
 const DEPTS = ['department1','department2','department3','department4'];
 const LESSONS = ['1','2','3'];
+
+function DeptHub() {
+  return (
+    <div style={{ padding: 16 }}>
+      <h2>Learn Hub</h2>
+      <ul>
+        {DEPTS.map(d => {
+          const unlocked = isDeptUnlocked(d);
+          const done = isDeptCompleted(d);
+          const status = done ? 'completed' : unlocked ? 'unlocked' : 'locked';
+          return (
+            <li key={d} style={{ margin: '8px 0' }}>
+              <Link to={unlocked ? `/learn/${d}/1` : '#'} style={{ color: unlocked ? '#ffd166' : '#888' }}>
+                {d}
+              </Link>
+              <span style={{ marginLeft: 8 }}><CohortBadge status={status} /></span>
+              {unlocked && <span style={{ marginLeft: 8 }}><Link to={`/quiz/${d}`}>Quiz</Link></span>}
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
 
 function DeptNav({ deptId, active }) {
   return (
@@ -40,8 +64,11 @@ function DeptLessonPage() {
   const { deptId, lessonId } = useParams();
   const navigate = useNavigate();
   if (!DEPTS.includes(deptId || '')) return <Placeholder text="Unknown department" />;
+
+  // Gate by unlock
+  if (!isDeptUnlocked(deptId)) return <Placeholder text="This department is locked. Pass the previous quiz to unlock." />;
+
   if (!LESSONS.includes(lessonId || '')) {
-    // default to lesson 1 if missing/bad
     navigate(`/learn/${deptId}/1`, { replace: true });
     return null;
   }
@@ -66,7 +93,7 @@ export default function App() {
         <Routes>
           <Route path="/" element={<Placeholder text="home" />} />
           <Route path="/profile" element={<Placeholder text="profile" />} />
-          <Route path="/learn" element={<Placeholder text="Pick a department: /learn/department1/1" />} />
+          <Route path="/learn" element={<DeptHub />} />
           <Route path="/learn/:deptId/:lessonId" element={<DeptLessonPage />} />
           <Route path="/quiz/:deptId" element={<QuizEngine />} />
           <Route path="/dashboard" element={<RewardSummary />} />
@@ -79,4 +106,3 @@ export default function App() {
     </BrowserRouter>
   );
 }
-

--- a/packages/frontend/src/components/CohortBadge.jsx
+++ b/packages/frontend/src/components/CohortBadge.jsx
@@ -1,3 +1,13 @@
-export default function CohortBadge({ name }) {
-  return <span style={{ background: '#555', padding: '2px 6px', borderRadius: '4px' }}>{name}</span>;
+export default function CohortBadge({ status }) {
+  const styles = {
+    locked: { background: '#444', color: '#fff', label: 'locked' },
+    unlocked: { background: '#ffd166', color: '#111', label: 'unlocked' },
+    completed: { background: '#4caf50', color: '#fff', label: 'completed' }
+  };
+  const { background, color, label } = styles[status] || { background: '#555', color: '#fff', label: status };
+  return (
+    <span style={{ background, color, padding: '2px 6px', borderRadius: '4px', fontSize: 12 }}>
+      {label}
+    </span>
+  );
 }

--- a/packages/frontend/src/components/QuizEngine.jsx
+++ b/packages/frontend/src/components/QuizEngine.jsx
@@ -1,5 +1,10 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
+import { markDeptCompleted, readProgress } from '../store/progress';
+
+const PASS_PCT = 70;
+const TIMER_SEC = 8 * 60;
+const COOLDOWN_SEC = 5 * 60;
 
 function shuffle(arr) {
   const a = arr.slice();
@@ -10,16 +15,39 @@ function shuffle(arr) {
   return a;
 }
 
+function cooldownKey(deptId) { return `lythera_cooldown_${deptId}`; }
+
 export default function QuizEngine() {
   const { deptId } = useParams();
-  const [status, setStatus] = useState('loading'); // loading | ready | done | error
+  const [status, setStatus] = useState('loading'); // loading | ready | done | error | locked
   const [items, setItems] = useState([]);
   const [answers, setAnswers] = useState({});
   const [score, setScore] = useState(0);
+  const [left, setLeft] = useState(TIMER_SEC); // seconds
+  const [cooldownLeft, setCooldownLeft] = useState(0);
 
   const uri = deptId ? `/content/${deptId}/questions.json` : null;
 
   useEffect(() => {
+    if (!deptId) return;
+    // cooldown check
+    const until = Number(localStorage.getItem(cooldownKey(deptId)) || 0);
+    const now = Math.floor(Date.now() / 1000);
+    if (until > now) {
+      setCooldownLeft(until - now);
+      setStatus('locked');
+      const t = setInterval(() => {
+        const now2 = Math.floor(Date.now() / 1000);
+        const remain = Math.max(0, until - now2);
+        setCooldownLeft(remain);
+        if (remain === 0) { clearInterval(t); setStatus('loading'); }
+      }, 1000);
+      return () => clearInterval(t);
+    }
+  }, [deptId]);
+
+  useEffect(() => {
+    if (status !== 'loading') return;
     let cancelled = false;
     async function load() {
       try {
@@ -30,6 +58,7 @@ export default function QuizEngine() {
         if (!cancelled) {
           setItems(shuffle(json).slice(0, Math.min(10, json.length)));
           setStatus('ready');
+          setLeft(TIMER_SEC);
         }
       } catch (e) {
         console.error(e);
@@ -38,7 +67,24 @@ export default function QuizEngine() {
     }
     load();
     return () => { cancelled = true; };
-  }, [uri]);
+  }, [uri, status]);
+
+  // timer
+  useEffect(() => {
+    if (status !== 'ready') return;
+    const id = setInterval(() => {
+      setLeft(s => {
+        const n = s - 1;
+        if (n <= 0) {
+          clearInterval(id);
+          handleSubmit(true);
+          return 0;
+        }
+        return n;
+      });
+    }, 1000);
+    return () => clearInterval(id);
+  }, [status]); // eslint-disable-line
 
   function toggleChoice(qIdx, cIdx) {
     setAnswers(a => {
@@ -65,33 +111,55 @@ export default function QuizEngine() {
     }, 0);
   }, [answers, items]);
 
-  function submit() {
+  function handleSubmit(auto = false) {
+    const pct = total ? Math.round((correctCount / total) * 100) : 0;
     setScore(correctCount);
+    const passed = pct >= PASS_PCT;
     setStatus('done');
+
+    if (passed) {
+      markDeptCompleted(deptId);
+    } else if (!auto) {
+      const until = Math.floor(Date.now() / 1000) + COOLDOWN_SEC;
+      localStorage.setItem(cooldownKey(deptId), String(until));
+      setCooldownLeft(COOLDOWN_SEC);
+    }
   }
 
   if (!deptId) return <div style={{ padding: 16 }}>No department</div>;
+  if (status === 'locked') {
+    return <div style={{ padding: 16, color: '#ffd166' }}>Retry available in {Math.ceil(cooldownLeft)}s…</div>;
+  }
   if (status === 'loading') return <div style={{ padding: 16 }}>Loading questions…</div>;
   if (status === 'error') return <div style={{ padding: 16, color: '#f66' }}>Failed to load {uri}</div>;
 
   if (status === 'done') {
     const pct = total ? Math.round((score / total) * 100) : 0;
+    const p = readProgress();
+    const next = ['department1','department2','department3','department4']
+      .find((_, i, arr) => p.unlocked[arr[i + 1]]);
     return (
       <div style={{ padding: 16 }}>
         <h2>Quiz Result — {deptId}</h2>
         <p>Score: {score} / {total} ({pct}%)</p>
-        <Link to={`/learn/${deptId}/1`} style={{ color: '#ffd166' }}>Back to lessons</Link>
+        <div style={{ display: 'flex', gap: 12 }}>
+          <Link to={`/learn/${deptId}/1`} style={{ color: '#ffd166' }}>Back to lessons</Link>
+          <Link to="/learn" style={{ color: '#ffd166' }}>Learn Hub</Link>
+        </div>
       </div>
     );
   }
 
+  // status === 'ready'
   return (
     <div style={{ padding: 16 }}>
       <h2>Quiz — {deptId}</h2>
+      <div style={{ marginBottom: 10 }}>Time left: {Math.ceil(left)}s • Pass: {PASS_PCT}%</div>
       <ol>
         {items.map((it, idx) => (
           <li key={idx} style={{ margin: '12px 0' }}>
             <div style={{ marginBottom: 8 }}>{it.q}</div>
+
             {it.a && (
               <input
                 type="text"
@@ -101,6 +169,7 @@ export default function QuizEngine() {
                 style={{ width: '100%', maxWidth: 420, padding: 8, background: '#222', color: '#fff', border: '1px solid #444', borderRadius: 6 }}
               />
             )}
+
             {it.choices && (
               <div>
                 {it.choices.map((choice, cIdx) => (
@@ -120,8 +189,7 @@ export default function QuizEngine() {
           </li>
         ))}
       </ol>
-      <button onClick={submit} style={{ padding: '8px 14px', borderRadius: 6 }}>Submit</button>
+      <button onClick={() => handleSubmit(false)} style={{ padding: '8px 14px', borderRadius: 6 }}>Submit</button>
     </div>
   );
 }
-

--- a/packages/frontend/src/store/progress.js
+++ b/packages/frontend/src/store/progress.js
@@ -1,0 +1,35 @@
+const KEY = 'lythera_progress_v1';
+
+export function readProgress() {
+  try {
+    return JSON.parse(localStorage.getItem(KEY)) || { completed: {}, unlocked: { department1: true } };
+  } catch {
+    return { completed: {}, unlocked: { department1: true } };
+  }
+}
+
+export function writeProgress(p) {
+  localStorage.setItem(KEY, JSON.stringify(p));
+}
+
+export function markDeptCompleted(deptId) {
+  const p = readProgress();
+  p.completed[deptId] = { at: Date.now() };
+  // unlock next department
+  const order = ['department1','department2','department3','department4'];
+  const idx = order.indexOf(deptId);
+  const next = order[idx + 1];
+  if (next) p.unlocked[next] = true;
+  writeProgress(p);
+  return p;
+}
+
+export function isDeptUnlocked(deptId) {
+  const p = readProgress();
+  return !!p.unlocked[deptId];
+}
+
+export function isDeptCompleted(deptId) {
+  const p = readProgress();
+  return !!p.completed[deptId];
+}


### PR DESCRIPTION
## Summary
- track and persist department progress in localStorage
- gate lesson routes and quiz access based on completion
- add quiz timer with pass/fail handling and cooldown
- show department status via CohortBadge

## Testing
- `yarn workspaces focus frontend` *(fails: Error when performing the request to https://repo.yarnpkg.com/...)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@graphprotocol%2fgraph-cli)*

------
https://chatgpt.com/codex/tasks/task_e_68b041305860832b83fc8c3e7b873bf1