### PR TITLE
feat: on-chain enroll + subgraph reads

### DIFF
--- a/packages/frontend/src/App.jsx
+++ b/packages/frontend/src/App.jsx
@@ -1,4 +1,5 @@
 import { BrowserRouter, Routes, Route, Link, useParams, useNavigate } from 'react-router-dom';
+import { useState } from 'react';
 import WalletButton from './components/WalletButton';
 import NetworkGuard from './components/NetworkGuard';
 import MarkdownRenderer from './components/MarkdownRenderer';
@@ -13,10 +14,13 @@ function Placeholder({ text }) { return <div style={{ padding: 16 }}>{text}</div
 const DEPTS = ['department1','department2','department3','department4'];
 const LESSONS = ['1','2','3'];
 
-function DeptHub() {
+function DeptHub({ address }) {
   return (
     <div style={{ padding: 16 }}>
       <h2>Learn Hub</h2>
+      <div style={{ margin: '12px 0' }}>
+        <CohortBadge address={address} cohortId={1} cap={100} />
+      </div>
       <ul>
         {DEPTS.map(d => {
           const unlocked = isDeptUnlocked(d);
@@ -27,7 +31,7 @@ function DeptHub() {
               <Link to={unlocked ? `/learn/${d}/1` : '#'} style={{ color: unlocked ? '#ffd166' : '#888' }}>
                 {d}
               </Link>
-              <span style={{ marginLeft: 8 }}><CohortBadge status={status} /></span>
+              <span style={{ marginLeft: 8, fontSize: 12 }}>{status}</span>
               {unlocked && <span style={{ marginLeft: 8 }}><Link to={`/quiz/${d}`}>Quiz</Link></span>}
             </li>
           );
@@ -84,19 +88,21 @@ function DeptLessonPage() {
 }
 
 export default function App() {
+  const [addr, setAddr] = useState();
+
   return (
     <BrowserRouter>
       <NetworkGuard>
         <div style={{ padding: 12 }}>
-          <WalletButton />
+          <WalletButton onAddressChange={setAddr} />
         </div>
         <Routes>
           <Route path="/" element={<Placeholder text="home" />} />
           <Route path="/profile" element={<Placeholder text="profile" />} />
-          <Route path="/learn" element={<DeptHub />} />
+          <Route path="/learn" element={<DeptHub address={addr} />} />
           <Route path="/learn/:deptId/:lessonId" element={<DeptLessonPage />} />
           <Route path="/quiz/:deptId" element={<QuizEngine />} />
-          <Route path="/dashboard" element={<RewardSummary />} />
+          <Route path="/dashboard" element={<RewardSummary address={addr} />} />
           <Route path="/admin" element={<AdminPublisher />} />
           <Route path="/community" element={<Placeholder text="community" />} />
           <Route path="/blog" element={<Placeholder text="blog" />} />

--- a/packages/frontend/src/abi/LearnToEarnRewarder.min.json
+++ b/packages/frontend/src/abi/LearnToEarnRewarder.min.json
@@ -1,0 +1,6 @@
+[
+  { "anonymous":false,"inputs":[
+      {"indexed":true,"internalType":"address","name":"to","type":"address"},
+      {"indexed":false,"internalType":"uint256","name":"amount","type":"uint256"}],
+    "name":"Claimed","type":"event"}
+]

--- a/packages/frontend/src/abi/LearnerRegistry.min.json
+++ b/packages/frontend/src/abi/LearnerRegistry.min.json
@@ -1,0 +1,8 @@
+[
+  { "inputs":[{"internalType":"uint256","name":"cohortId","type":"uint256"}],
+    "name":"enroll","outputs":[],"stateMutability":"nonpayable","type":"function"},
+  { "anonymous":false,"inputs":[
+      {"indexed":true,"internalType":"address","name":"learner","type":"address"},
+      {"indexed":false,"internalType":"uint256","name":"cohortId","type":"uint256"}],
+    "name":"Enrolled","type":"event"}
+]

--- a/packages/frontend/src/components/CohortBadge.jsx
+++ b/packages/frontend/src/components/CohortBadge.jsx
@@ -1,13 +1,44 @@
-export default function CohortBadge({ status }) {
-  const styles = {
-    locked: { background: '#444', color: '#fff', label: 'locked' },
-    unlocked: { background: '#ffd166', color: '#111', label: 'unlocked' },
-    completed: { background: '#4caf50', color: '#fff', label: 'completed' }
-  };
-  const { background, color, label } = styles[status] || { background: '#555', color: '#fff', label: status };
+import { useEffect, useState } from 'react';
+import { cohortEnrollmentCount, myEnrollments } from '../lib/subgraph';
+import EnrollButton from './EnrollButton';
+
+export default function CohortBadge({ address, cohortId = 1, cap = 100 }) {
+  const [count, setCount] = useState(0);
+  const [enrolled, setEnrolled] = useState(false);
+
+  useEffect(() => {
+    let live = true;
+    (async () => {
+      try {
+        const c = await cohortEnrollmentCount(cohortId);
+        if (live) setCount(c);
+      } catch {}
+    })();
+    return () => { live = false; };
+  }, [cohortId]);
+
+  useEffect(() => {
+    if (!address) return;
+    let live = true;
+    (async () => {
+      try {
+        const mine = await myEnrollments(address);
+        if (live) setEnrolled(mine.some(id => String(id) === String(cohortId)));
+      } catch {}
+    })();
+    return () => { live = false; };
+  }, [address, cohortId]);
+
+  const spotsLeft = Math.max(0, cap - count);
+
   return (
-    <span style={{ background, color, padding: '2px 6px', borderRadius: '4px', fontSize: 12 }}>
-      {label}
-    </span>
+    <div style={{ display:'inline-flex', gap:10, alignItems:'center', background:'#333', padding:'6px 10px', borderRadius:8 }}>
+      <span>Cohort {cohortId}</span>
+      <span>{enrolled ? '✅ Enrolled' : '🔒 Not enrolled'}</span>
+      <span>Spots left: {spotsLeft}</span>
+      {!enrolled && spotsLeft > 0 && (
+        <EnrollButton cohortId={cohortId} onEnrolled={() => setEnrolled(true)} />
+      )}
+    </div>
   );
 }

--- a/packages/frontend/src/components/EnrollButton.jsx
+++ b/packages/frontend/src/components/EnrollButton.jsx
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+import { ethers } from 'ethers';
+import { getSigner, learnerRegistry } from '../lib/contracts';
+
+export default function EnrollButton({ cohortId = 1, onEnrolled }) {
+  const [busy, setBusy] = useState(false);
+
+  async function enroll() {
+    try {
+      setBusy(true);
+      const signer = await getSigner();
+      // Ensure BSC 56
+      const net = await signer.provider.getNetwork();
+      if (net.chainId !== 56n) {
+        await signer.provider.send('wallet_switchEthereumChain', [{ chainId: '0x38' }]);
+      }
+      const reg = learnerRegistry(signer);
+      const tx = await reg.enroll(ethers.toBigInt(cohortId));
+      const receipt = await tx.wait();
+      onEnrolled?.(receipt);
+      alert('Enrolled!');
+    } catch (e) {
+      console.error(e);
+      alert(e?.reason || e?.message || 'Enroll failed');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <button onClick={enroll} disabled={busy}>
+      {busy ? 'Enrolling…' : `Enroll (cohort ${cohortId})`}
+    </button>
+  );
+}

--- a/packages/frontend/src/components/RewardSummary.jsx
+++ b/packages/frontend/src/components/RewardSummary.jsx
@@ -1,3 +1,51 @@
-export default function RewardSummary({ amount = 0 }) {
-  return <div>Rewards: {amount} GCC</div>;
+import { useEffect, useState } from 'react';
+import { totalClaimed } from '../lib/subgraph';
+import { readProgress } from '../store/progress';
+
+async function fetchRewardsTable() {
+  try {
+    const res = await fetch('/content/rewards.json');
+    return await res.json(); // { "Beginner": 5, ... }
+  } catch { return {}; }
+}
+
+export default function RewardSummary({ address }) {
+  const [claimed, setClaimed] = useState(0);
+  const [eligible, setEligible] = useState(0);
+
+  useEffect(() => {
+    let live = true;
+    (async () => {
+      const table = await fetchRewardsTable();
+      const p = readProgress();
+      const sum =
+        (p.completed.department1 ? (table['Beginner'] || 0) : 0) +
+        (p.completed.department2 ? (table['Intermediate'] || 0) : 0) +
+        (p.completed.department3 ? (table['Advanced'] || 0) : 0) +
+        (p.completed.department4 ? (table['GCC Spotlight'] || 0) : 0);
+      if (live) setEligible(sum);
+    })();
+    return () => { live = false; };
+  }, []);
+
+  useEffect(() => {
+    if (!address) return;
+    let live = true;
+    (async () => {
+      try {
+        const total = await totalClaimed(address);
+        if (live) setClaimed(total);
+      } catch {}
+    })();
+    return () => { live = false; };
+  }, [address]);
+
+  return (
+    <div style={{ padding: 16 }}>
+      <h3>Rewards</h3>
+      <div>Eligible (based on your completed departments): <b>{eligible} GCC</b></div>
+      <div>Claimed on-chain: <b>{claimed} GCC</b></div>
+      <small style={{ color:'#aaa' }}>Eligibility currently computed client-side; claim history from subgraph.</small>
+    </div>
+  );
 }

--- a/packages/frontend/src/components/WalletButton.jsx
+++ b/packages/frontend/src/components/WalletButton.jsx
@@ -7,7 +7,7 @@ const CHAIN_ID_HEX = '0x38'; // 56
 const RPC_URL = import.meta.env.VITE_RPC_URL || 'https://bsc-dataseed.binance.org';
 const EXPLORER_URL = import.meta.env.VITE_EXPLORER_URL || 'https://bscscan.com';
 
-export default function WalletButton() {
+export default function WalletButton(props) {
   const [address, setAddress] = useState();
   const mounted = useRef(true);
 
@@ -50,6 +50,7 @@ export default function WalletButton() {
       await ensureBSC();
       const accounts = await provider.send('eth_requestAccounts', []);
       if (mounted.current) setAddress(accounts[0]);
+      props?.onAddressChange?.(accounts[0]);
     } catch (e) {
       console.error('[wallet connect] error:', e);
       alert(e?.message || 'Wallet connect failed.');
@@ -58,9 +59,9 @@ export default function WalletButton() {
 
   function disconnect() {
     if (mounted.current) setAddress(undefined);
+    props?.onAddressChange?.(undefined);
   }
 
   const label = address ? `${address.slice(0, 6)}…${address.slice(-4)}` : 'Connect Wallet';
   return <button onClick={address ? disconnect : connect}>{label}</button>;
 }
-

--- a/packages/frontend/src/lib/contracts.js
+++ b/packages/frontend/src/lib/contracts.js
@@ -1,0 +1,26 @@
+import { ethers } from 'ethers';
+import LREG from '../abi/LearnerRegistry.min.json';
+import REWARDER from '../abi/LearnToEarnRewarder.min.json';
+
+export function getBrowserProvider() {
+  if (!window.ethereum) throw new Error('MetaMask not detected');
+  return new ethers.BrowserProvider(window.ethereum);
+}
+
+export async function getSigner() {
+  const provider = getBrowserProvider();
+  await provider.send('eth_requestAccounts', []);
+  return await provider.getSigner();
+}
+
+export function learnerRegistry(signerOrProvider) {
+  const addr = import.meta.env.VITE_LEARNER_REGISTRY_ADDRESS;
+  if (!addr) throw new Error('VITE_LEARNER_REGISTRY_ADDRESS missing');
+  return new ethers.Contract(addr, LREG, signerOrProvider);
+}
+
+export function rewarder(signerOrProvider) {
+  const addr = import.meta.env.VITE_REWARDER_ADDRESS;
+  if (!addr) throw new Error('VITE_REWARDER_ADDRESS missing');
+  return new ethers.Contract(addr, REWARDER, signerOrProvider);
+}

--- a/packages/frontend/src/lib/subgraph.js
+++ b/packages/frontend/src/lib/subgraph.js
@@ -1,0 +1,46 @@
+const SUBGRAPH = import.meta.env.VITE_SUBGRAPH_URL;
+
+export async function gql(query, variables = {}) {
+  if (!SUBGRAPH) throw new Error('VITE_SUBGRAPH_URL missing');
+  const res = await fetch(SUBGRAPH, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ query, variables })
+  });
+  const json = await res.json();
+  if (json.errors) throw new Error(json.errors.map(e => e.message).join('; '));
+  return json.data;
+}
+
+/** Count enrollments in a cohort (first 1000) */
+export async function cohortEnrollmentCount(cohortId) {
+  const q = `
+    query($cohortId: BigInt!) {
+      enrolleds(first: 1000, where: { cohortId: $cohortId }) { id }
+    }
+  `;
+  const data = await gql(q, { cohortId: String(cohortId) });
+  return data.enrolleds.length;
+}
+
+/** Is this address enrolled (any cohort)? */
+export async function myEnrollments(addr) {
+  const q = `
+    query($addr: Bytes!) {
+      enrolleds(first: 1000, where: { learner: $addr }) { cohortId }
+    }
+  `;
+  const data = await gql(q, { addr: addr.toLowerCase() });
+  return data.enrolleds.map(e => e.cohortId);
+}
+
+/** Total claimed by address */
+export async function totalClaimed(addr) {
+  const q = `
+    query($addr: Bytes!) {
+      claimeds(first: 1000, where: { to: $addr }) { amount }
+    }
+  `;
+  const data = await gql(q, { addr: addr.toLowerCase() });
+  return data.claimeds.reduce((sum, c) => sum + Number(c.amount), 0);
+}


### PR DESCRIPTION
## Summary
- add minimal ABIs and contract helpers for learner registry and rewarder
- wire subgraph queries for cohort enrollment and claimed rewards
- add enroll UI with cohort badge, reward summary, and wallet callback

## Testing
- `yarn workspaces focus frontend` *(fails: Proxy response (403) when HTTP tunneling)*
- `yarn workspace frontend build` *(fails: Proxy response (403) when HTTP tunneling)*

------
https://chatgpt.com/codex/tasks/task_e_68b04342209c832bb3ac1423c66b0638