### PR TITLE
feat: add admin panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ build/
 .cache/
 out/
 lib/
+# allow source libs in frontend
+!packages/frontend/src/lib/
+!packages/frontend/src/lib/**
 .DS_Store
 .env
 

--- a/packages/frontend/.env.example
+++ b/packages/frontend/.env.example
@@ -1,0 +1,13 @@
+VITE_APP_NAME=Lythera Ecosystem
+VITE_CHAIN_ID=56
+VITE_RPC_URL=https://bsc-dataseed.binance.org
+VITE_EXPLORER_URL=https://bscscan.com
+VITE_WC_PROJECT_ID=REPLACE_ME
+VITE_GCC_TOKEN_ADDRESS=0x092aC429b9c3450c9909433eB0662c3b7c13cF9A
+VITE_REWARDER_ADDRESS=0xRewarder
+VITE_CONTENT_REGISTRY_ADDRESS=0xContentRegistry
+VITE_LEARNER_REGISTRY_ADDRESS=0xLearnerRegistry
+VITE_SUBGRAPH_URL=https://api.thegraph.com/subgraphs/name/lythera/bsc
+VITE_CONTENT_GATEWAY=https://ipfs.io/ipfs/
+VITE_ARWEAVE_GATEWAY=https://arweave.net/
+VITE_ADMIN_ADDRESSES=0xadmin1,0xadmin2

--- a/packages/frontend/src/App.jsx
+++ b/packages/frontend/src/App.jsx
@@ -4,10 +4,10 @@ import WalletButton from './components/WalletButton';
 import NetworkGuard from './components/NetworkGuard';
 import MarkdownRenderer from './components/MarkdownRenderer';
 import QuizEngine from './components/QuizEngine';
-import AdminPublisher from './components/AdminPublisher';
 import RewardSummary from './components/RewardSummary';
 import CohortBadge from './components/CohortBadge';
 import { gatingFor } from './lib/gating';
+import AdminPanel from './pages/AdminPanel';
 
 function Placeholder({ text }) { return <div style={{ padding: 16 }}>{text}</div>; }
 
@@ -123,8 +123,8 @@ export default function App() {
           <Route path="/learn" element={<DeptHub address={addr} />} />
           <Route path="/learn/:deptId/:lessonId" element={<DeptLessonPage address={addr} />} />
           <Route path="/quiz/:deptId" element={<QuizEngine />} />
-          <Route path="/dashboard" element={<RewardSummary address={addr} />} />
-          <Route path="/admin" element={<AdminPublisher />} />
+            <Route path="/dashboard" element={<RewardSummary address={addr} />} />
+            <Route path="/admin" element={<AdminPanel address={addr} />} />
           <Route path="/community" element={<Placeholder text="community" />} />
           <Route path="/blog" element={<Placeholder text="blog" />} />
           <Route path="/legal/*" element={<Placeholder text="legal" />} />

--- a/packages/frontend/src/lib/admin.js
+++ b/packages/frontend/src/lib/admin.js
@@ -1,0 +1,8 @@
+export function isAdmin(address) {
+  if (!address) return false;
+  const list = (import.meta.env.VITE_ADMIN_ADDRESSES || '')
+    .split(',')
+    .map(s => s.trim().toLowerCase())
+    .filter(Boolean);
+  return list.includes(address.toLowerCase());
+}

--- a/packages/frontend/src/lib/claims.js
+++ b/packages/frontend/src/lib/claims.js
@@ -1,0 +1,34 @@
+// Build an EIP-712 claim payload JSON (unsigned). Ops can sign with tools/claim-signer.js
+// amount: number (GCC smallest units? keep as raw token units for now)
+// nonce: uint256 as string/number; deadlineSec: UNIX seconds
+export function buildClaimJson({ to, amount, nonce, deadlineSec }) {
+  const chainId = Number(import.meta.env.VITE_CHAIN_ID || 56);
+  const verifyingContract = import.meta.env.VITE_REWARDER_ADDRESS;
+  const domain = { name: 'LearnToEarnRewarder', version: '1', chainId, verifyingContract };
+  const types = {
+    Claim: [
+      { name: 'to', type: 'address' },
+      { name: 'amount', type: 'uint256' },
+      { name: 'deadline', type: 'uint256' },
+      { name: 'nonce', type: 'uint256' }
+    ]
+  };
+  const value = { to, amount: String(amount), deadline: String(deadlineSec), nonce: String(nonce) };
+  return { domain, types, value, signature: '' }; // signature left blank; fill after offline sign
+}
+
+// Optional helper: compute eligible GCC from completed depts
+export async function computeEligibleFromRewards(completedDepts) {
+  try {
+    const res = await fetch('/content/rewards.json');
+    const table = await res.json();
+    let sum = 0;
+    for (const d of completedDepts) {
+      if (d === 1) sum += Number(table['Beginner'] || 0);
+      if (d === 2) sum += Number(table['Intermediate'] || 0);
+      if (d === 3) sum += Number(table['Advanced'] || 0);
+      if (d === 4) sum += Number(table['GCC Spotlight'] || 0);
+    }
+    return sum; // GCC (human units) — convert to token units outside if needed
+  } catch { return 0; }
+}

--- a/packages/frontend/src/lib/contracts.js
+++ b/packages/frontend/src/lib/contracts.js
@@ -24,3 +24,9 @@ export function rewarder(signerOrProvider) {
   if (!addr) throw new Error('VITE_REWARDER_ADDRESS missing');
   return new ethers.Contract(addr, REWARDER, signerOrProvider);
 }
+
+export async function markCompletedTx(learner, deptId) {
+  const signer = await getSigner();
+  const reg = learnerRegistry(signer);
+  return reg.markCompleted(learner, BigInt(deptId));
+}

--- a/packages/frontend/src/lib/subgraph.js
+++ b/packages/frontend/src/lib/subgraph.js
@@ -54,3 +54,23 @@ export async function completedByDept(addr) {
   const d = await gql(q, { addr: addr.toLowerCase() });
   return d.completeds.map(c => Number(c.deptId));
 }
+
+export async function listCompletions({ first = 100, skip = 0, learner }) {
+  const q = `
+    query($first: Int!, $skip: Int!, $learner: Bytes) {
+      completeds(first: $first, skip: $skip, orderBy: id, orderDirection: desc,
+        where: { learner: $learner }) {
+        id
+        learner
+        deptId
+      }
+    }
+  `;
+  const vars = { first, skip, learner: learner ? learner.toLowerCase() : null };
+  const data = await gql(q, vars);
+  return data.completeds.map(c => ({ id: c.id, learner: c.learner, deptId: Number(c.deptId) }));
+}
+
+export async function completionsByLearner(learner) {
+  return listCompletions({ learner, first: 1000, skip: 0 });
+}

--- a/packages/frontend/src/pages/AdminPanel.jsx
+++ b/packages/frontend/src/pages/AdminPanel.jsx
@@ -1,0 +1,166 @@
+import { useEffect, useState } from 'react';
+import { isAdmin } from '../lib/admin';
+import { listCompletions, completionsByLearner } from '../lib/subgraph';
+import { markCompletedTx } from '../lib/contracts';
+import { buildClaimJson, computeEligibleFromRewards } from '../lib/claims';
+
+function Row({ c }) {
+  return (
+    <tr>
+      <td style={{ padding: 6 }}>{c.learner}</td>
+      <td style={{ padding: 6, textAlign: 'center' }}>{c.deptId}</td>
+      <td style={{ padding: 6, fontSize: 12, color: '#aaa' }}>{c.id}</td>
+    </tr>
+  );
+}
+
+export default function AdminPanel({ address }) {
+  const [ok, setOk] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  const [filterAddr, setFilterAddr] = useState('');
+  const [items, setItems] = useState([]);
+  const [page, setPage] = useState(0);
+
+  // mark-completed form
+  const [mcAddr, setMcAddr] = useState('');
+  const [mcDept, setMcDept] = useState('1');
+
+  // claim builder form
+  const [claimAddr, setClaimAddr] = useState('');
+  const [claimNonce, setClaimNonce] = useState('0');
+  const [claimHours, setClaimHours] = useState('72');
+  const [claimAmount, setClaimAmount] = useState(''); // human GCC
+
+  useEffect(() => { setOk(isAdmin(address)); }, [address]);
+
+  useEffect(() => {
+    let live = true;
+    (async () => {
+      try {
+        setBusy(true);
+        const pageSize = 100;
+        const res = await listCompletions({
+          learner: filterAddr || undefined,
+          first: pageSize,
+          skip: page * pageSize
+        });
+        if (live) setItems(res);
+      } finally { if (live) setBusy(false); }
+    })();
+    return () => { live = false; };
+  }, [filterAddr, page]);
+
+  async function markCompleted() {
+    try {
+      setBusy(true);
+      const tx = await markCompletedTx(mcAddr, Number(mcDept));
+      alert(`tx sent: ${tx.hash}`);
+      await tx.wait();
+      alert('Completed recorded on-chain');
+    } catch (e) {
+      console.error(e);
+      alert(e?.reason || e?.message || 'markCompleted failed');
+    } finally { setBusy(false); }
+  }
+
+  async function autoAmountFromCompletions() {
+    if (!claimAddr) return;
+    const cs = await completionsByLearner(claimAddr);
+    const depts = cs.map(c => c.deptId);
+    const sum = await computeEligibleFromRewards(depts);
+    setClaimAmount(String(sum));
+  }
+
+  function downloadClaimJson() {
+    try {
+      const deadlineSec = Math.floor(Date.now() / 1000) + Number(claimHours || '72') * 3600;
+      // convert human GCC -> token units if needed (leave as human if GCC has 18 decimals; adapt later)
+      const payload = buildClaimJson({
+        to: claimAddr,
+        amount: claimAmount,   // NOTE: if token has 18 decimals, multiply by 1e18 before using on-chain
+        nonce: claimNonce,
+        deadlineSec
+      });
+      const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
+      const a = document.createElement('a');
+      a.href = URL.createObjectURL(blob);
+      a.download = `${claimAddr.toLowerCase()}-claim.json`;
+      document.body.appendChild(a);
+      a.click();
+      URL.revokeObjectURL(a.href);
+      a.remove();
+    } catch (e) {
+      console.error(e);
+      alert('Failed to build claim JSON');
+    }
+  }
+
+  if (!ok) {
+    return <div style={{ padding: 16 }}>
+      <h2>Admin Panel</h2>
+      <p>Your address is not in <code>VITE_ADMIN_ADDRESSES</code>.</p>
+    </div>;
+  }
+
+  return (
+    <div style={{ padding: 16 }}>
+      <h2>Admin Panel</h2>
+
+      {/* Filter / pager */}
+      <div style={{ display: 'flex', gap: 10, alignItems: 'center', margin: '8px 0' }}>
+        <input value={filterAddr} onChange={e => setFilterAddr(e.target.value)}
+          placeholder="Filter by learner (0x...)" style={{ width: 360, padding: 6 }} />
+        <button onClick={() => setPage(p => Math.max(0, p - 1))} disabled={page === 0}>Prev</button>
+        <span>Page {page + 1}</span>
+        <button onClick={() => setPage(p => p + 1)}>Next</button>
+        {busy && <span style={{ color: '#aaa' }}>Loading…</span>}
+      </div>
+
+      {/* Completions table */}
+      <table style={{ width: '100%', borderCollapse: 'collapse', marginBottom: 16 }}>
+        <thead>
+          <tr>
+            <th style={{ textAlign: 'left', padding: 6 }}>Learner</th>
+            <th style={{ textAlign: 'center', padding: 6 }}>Dept</th>
+            <th style={{ textAlign: 'left', padding: 6 }}>Event ID</th>
+          </tr>
+        </thead>
+        <tbody>{items.map(c => <Row key={c.id} c={c} />)}</tbody>
+      </table>
+
+      {/* Mark Completed */}
+      <div style={{ margin: '16px 0', padding: 12, border: '1px solid #444', borderRadius: 8 }}>
+        <h3>Mark Completed (on-chain)</h3>
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+          <input placeholder="0xLearner" value={mcAddr} onChange={e => setMcAddr(e.target.value)} style={{ width: 360, padding: 6 }} />
+          <select value={mcDept} onChange={e => setMcDept(e.target.value)}>
+            <option value="1">Dept 1</option><option value="2">Dept 2</option>
+            <option value="3">Dept 3</option><option value="4">Dept 4</option>
+          </select>
+          <button onClick={markCompleted} disabled={busy}>Mark Completed</button>
+        </div>
+        <small style={{ color: '#aaa' }}>Requires the connected wallet to have ADMIN_ROLE on LearnerRegistry.</small>
+      </div>
+
+      {/* Generate Claim JSON */}
+      <div style={{ margin: '16px 0', padding: 12, border: '1px solid #444', borderRadius: 8 }}>
+        <h3>Generate Claim JSON (offline sign later)</h3>
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+          <input placeholder="0xLearner" value={claimAddr} onChange={e => setClaimAddr(e.target.value)} style={{ width: 360, padding: 6 }} />
+          <input placeholder="Amount (GCC, human)" value={claimAmount} onChange={e => setClaimAmount(e.target.value)} style={{ width: 180, padding: 6 }} />
+          <input placeholder="Nonce" value={claimNonce} onChange={e => setClaimNonce(e.target.value)} style={{ width: 90, padding: 6 }} />
+          <input placeholder="Deadline (hours)" value={claimHours} onChange={e => setClaimHours(e.target.value)} style={{ width: 120, padding: 6 }} />
+          <button onClick={autoAmountFromCompletions}>Auto amount from completions</button>
+          <button onClick={downloadClaimJson}>Download JSON</button>
+        </div>
+        <small style={{ color: '#aaa' }}>
+          This JSON includes EIP-712 domain/types/value; signature is blank. Sign it offline with the ops key
+          using <code>packages/tools/claim-signer.js</code> or a Safe module, then place the signed file under
+          <code>/public/content/claims/&lt;address&gt;.json</code>.
+        </small>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add admin allow list helper and env variable
- support marking completions and fetching data from subgraph
- add claim JSON builder and admin panel page with routes

## Testing
- `yarn lint` *(fails: Error when performing the request to https://repo.yarnpkg.com/4.9.4/packages/yarnpkg-cli/bin/yarn.js)*
- `yarn workspace frontend build` *(fails: Error when performing the request to https://repo.yarnpkg.com/4.9.4/packages/yarnpkg-cli/bin/yarn.js)*

------
https://chatgpt.com/codex/tasks/task_e_68b047e93670832b83ecfb0cdd1720f1