### PR TITLE
frontend: disable quiz link when locked

### DIFF
--- a/packages/frontend/src/App.jsx
+++ b/packages/frontend/src/App.jsx
@@ -35,7 +35,16 @@ function DeptNav({ deptId, active }) {
           </Link>
         );
       })}
-      <Link to={`/quiz/${deptId}`} style={{ marginLeft: 'auto', color: '#ffd166' }}>
+      <Link
+        to={`/quiz/${deptId}`}
+        style={{
+          marginLeft: 'auto',
+          color: '#ffd166',
+          textDecoration: locked ? 'line-through' : 'none',
+          pointerEvents: locked ? 'none' : 'auto',
+          opacity: locked ? 0.5 : 1
+        }}
+      >
         {locked ? 'Locked (pass previous dept)' : 'Take Quiz →'}
       </Link>
     </div>


### PR DESCRIPTION
## Summary
- make quiz link unclickable when department is locked

## Testing
- `yarn lint` *(fails: Error when performing the request to https://repo.yarnpkg.com/4.9.4/packages/yarnpkg-cli/bin/yarn.js)*
- `yarn workspace frontend build` *(fails: Error when performing the request to https://repo.yarnpkg.com/4.9.4/packages/yarnpkg-cli/bin/yarn.js)*

------
https://chatgpt.com/codex/tasks/task_e_68b220b87a5c832bb6b73c3a78f8189e