### PR TITLE
feat: add layout and toast components

### DIFF
--- a/packages/frontend/src/App.jsx
+++ b/packages/frontend/src/App.jsx
@@ -6,6 +6,8 @@ import QuizEngine from './components/QuizEngine';
 import AdminPublisher from './components/AdminPublisher';
 import RewardSummary from './components/RewardSummary';
 import ChainStatus from './components/ChainStatus';
+import Layout from './components/Layout';
+import Toast from './components/Toast';
 import { hasPassed } from './utils/storage';
 
 function Placeholder({ text }) { return <div style={{ padding: 16 }}>{text}</div>; }
@@ -64,14 +66,16 @@ function DeptLessonPage() {
   const uri = `/content/${deptId}/lesson${lessonId}.md`;
   return (
     <div>
-      <div style={{ padding: 12, display: 'flex', alignItems: 'center' }}>
-        <WalletButton />
-        <ChainStatus />
-      </div>
+      {locked && (
+        <Toast message="Locked. Pass the previous department’s quiz to unlock." type="warn" />
+      )}
       <DeptNav deptId={deptId} active={lessonId} />
       <div style={{ padding: 16 }}>
-        {locked ? <em>Locked. Pass the previous department’s quiz to unlock.</em> :
-          <MarkdownRenderer uri={uri} title={`${deptId} • Lesson ${lessonId}`} />}
+        {locked ? (
+          <em>Locked. Pass the previous department’s quiz to unlock.</em>
+        ) : (
+          <MarkdownRenderer uri={uri} title={`${deptId} • Lesson ${lessonId}`} />
+        )}
       </div>
     </div>
   );
@@ -81,18 +85,20 @@ export default function App() {
   return (
     <BrowserRouter>
       <NetworkGuard>
-        <Routes>
-          <Route path="/" element={<Placeholder text="home" />} />
-          <Route path="/profile" element={<Placeholder text="profile" />} />
-          <Route path="/learn" element={<Placeholder text="Pick a department: /learn/department1/1" />} />
-          <Route path="/learn/:deptId/:lessonId" element={<DeptLessonPage />} />
-          <Route path="/quiz/:deptId" element={<QuizEngine passPct={70} timeLimitSec={480} />} />
-          <Route path="/dashboard" element={<RewardSummary />} />
-          <Route path="/admin" element={<AdminPublisher />} />
-          <Route path="/community" element={<Placeholder text="community" />} />
-          <Route path="/blog" element={<Placeholder text="blog" />} />
-          <Route path="/legal/*" element={<Placeholder text="legal" />} />
-        </Routes>
+        <Layout headerRight={<><WalletButton /><ChainStatus /></>}>
+          <Routes>
+            <Route path="/" element={<Placeholder text="home" />} />
+            <Route path="/profile" element={<Placeholder text="profile" />} />
+            <Route path="/learn" element={<Placeholder text="Pick a department: /learn/department1/1" />} />
+            <Route path="/learn/:deptId/:lessonId" element={<DeptLessonPage />} />
+            <Route path="/quiz/:deptId" element={<QuizEngine passPct={70} timeLimitSec={480} />} />
+            <Route path="/dashboard" element={<RewardSummary />} />
+            <Route path="/admin" element={<AdminPublisher />} />
+            <Route path="/community" element={<Placeholder text="community" />} />
+            <Route path="/blog" element={<Placeholder text="blog" />} />
+            <Route path="/legal/*" element={<Placeholder text="legal" />} />
+          </Routes>
+        </Layout>
       </NetworkGuard>
     </BrowserRouter>
   );

--- a/packages/frontend/src/components/Layout.jsx
+++ b/packages/frontend/src/components/Layout.jsx
@@ -1,0 +1,33 @@
+import { Link } from 'react-router-dom';
+
+export default function Layout({ children, headerRight }) {
+  return (
+    <div style={{ minHeight: '100vh', display: 'flex', flexDirection: 'column' }}>
+      <header style={{
+        background: '#1c1c1c',
+        padding: '12px 24px',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between'
+      }}>
+        <nav style={{ display: 'flex', gap: '16px' }}>
+          <Link to="/" style={{ color: '#ffd166' }}>Home</Link>
+          <Link to="/learn/department1/1">Learn</Link>
+          <Link to="/dashboard">Dashboard</Link>
+          <Link to="/community">Community</Link>
+        </nav>
+        <div style={{ display: 'flex', gap: 8 }}>
+          {headerRight}
+        </div>
+      </header>
+
+      <main style={{ flex: 1, padding: '24px', maxWidth: 960, margin: '0 auto' }}>
+        {children}
+      </main>
+
+      <footer style={{ background: '#111', color: '#888', textAlign: 'center', padding: '8px 16px' }}>
+        © 2025 Lythera Ecosystem • Learn Web3, Earn $GCC
+      </footer>
+    </div>
+  );
+}

--- a/packages/frontend/src/components/Toast.jsx
+++ b/packages/frontend/src/components/Toast.jsx
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react';
+
+export default function Toast({ message, type = 'info', duration = 3000, onDone }) {
+  const [show, setShow] = useState(true);
+
+  useEffect(() => {
+    const t = setTimeout(() => {
+      setShow(false);
+      onDone && onDone();
+    }, duration);
+    return () => clearTimeout(t);
+  }, [duration, onDone]);
+
+  if (!show) return null;
+
+  const colors = {
+    info: '#2196f3',
+    success: '#4caf50',
+    error: '#f44336',
+    warn: '#ff9800'
+  };
+
+  return (
+    <div style={{
+      position: 'fixed',
+      bottom: 20,
+      right: 20,
+      background: colors[type] || '#333',
+      color: '#fff',
+      padding: '10px 16px',
+      borderRadius: 8,
+      boxShadow: '0 2px 6px rgba(0,0,0,0.4)'
+    }}>
+      {message}
+    </div>
+  );
+}

--- a/packages/frontend/src/style.css
+++ b/packages/frontend/src/style.css
@@ -1,9 +1,23 @@
 body {
   background: #121212;
-  color: #fff;
-  font-family: sans-serif;
+  color: #f5f5f5;
+  font-family: 'Segoe UI', sans-serif;
+  margin: 0;
 }
+
+a {
+  color: #ffd166;
+  text-decoration: none;
+}
+a:hover { text-decoration: underline; }
+
 button {
   padding: 6px 12px;
   margin: 4px;
+  background: #333;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
 }
+button:hover { background: #444; }


### PR DESCRIPTION
## Summary
- Add reusable Layout with navigation header and footer
- Introduce Toast component for inline notifications
- Wire lessons and quiz pages into Layout and Toast; apply dark-mode friendly styles

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: vite not found; attempted `npm install` but received 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b224777630832b9e5ea0217ef26ac9